### PR TITLE
Mpi buffer integration

### DIFF
--- a/src/runtime-mpi.c
+++ b/src/runtime-mpi.c
@@ -11,78 +11,17 @@
 #include "shmem_internal.h"
 #include "uthash.h"
 
-#define MAX_KV_COUNT 10
-
+#define MAX_KV_COUNT 20
+#define MAX_KV_LENGTH 64
 
 static int rank = -1;
 static int size = 0;
-static char *kvs_name, *kvs_key, *kvs_value;
-static int max_name_len, max_key_len, max_val_len;
 static MPI_Comm SHMEM_RUNTIME_WORLD;
-static char** kv_store_all;
-static char** kv_store_me;
 static int length = 0;
 
-#define SINGLETON_KEY_LEN 128
-#define SINGLETON_VAL_LEN 256
+char* kv_store_me;
+char* kv_store_all;
 
-typedef struct {
-    char key[SINGLETON_KEY_LEN];
-    char val[SINGLETON_VAL_LEN];
-    UT_hash_handle hh;
-} singleton_kvs_t;
-
-singleton_kvs_t *singleton_kvs = NULL;
-
-static int
-encode(const void *inval, int invallen, char *outval, int outvallen)
-{
-    static unsigned char encodings[] = {
-        '0','1','2','3','4','5','6','7', 
-        '8','9','a','b','c','d','e','f' };
-    int i;
-
-    if (invallen * 2 + 1 > outvallen) {
-        return 1;
-    }
-
-    for (i = 0; i < invallen; i++) {
-        outval[2 * i] = encodings[((unsigned char *)inval)[i] & 0xf];
-        outval[2 * i + 1] = encodings[((unsigned char *)inval)[i] >> 4];
-    }
-
-    outval[invallen * 2] = '\0';
-
-    return 0;
-}
-
-static int
-decode(const char *inval, void *outval, size_t outvallen)
-{
-    size_t i;
-    char *ret = (char*) outval;
-
-    if (outvallen != strlen(inval) / 2) {
-        return 1;
-    }
-
-    for (i = 0 ; i < outvallen ; ++i) {
-        if (*inval >= '0' && *inval <= '9') {
-            ret[i] = *inval - '0';
-        } else {
-            ret[i] = *inval - 'a' + 10;
-        }
-        inval++;
-        if (*inval >= '0' && *inval <= '9') {
-            ret[i] |= ((*inval - '0') << 4);
-        } else {
-            ret[i] |= ((*inval - 'a' + 10) << 4);
-        }
-        inval++;
-    }
-
-    return 0;
-}
 
 int
 shmem_runtime_init(void)
@@ -132,33 +71,8 @@ shmem_runtime_init(void)
         return 5;
     }
 
-    if (size > 1) { 
-
-    	max_name_len = 128;
-        max_key_len = 128;
-        max_val_len = 128;
-
-        //WARN: THIS ASSUMES THAT YOU CAN ONLY HAVE 10 KEY VALUE PAIRS
-        kv_store_all = (char**) malloc(sizeof(char*) * MAX_KV_COUNT * 2); 
-        if(NULL == kv_store_all) return 6; //rename
-        kv_store_me = (char**) malloc(sizeof(char*) * MAX_KV_COUNT * 2);
-        if(NULL == kv_store_me) return 7; //rename
-
-    }
-    else {
-        /* Use a local KVS for singleton runs */
-        max_key_len = SINGLETON_KEY_LEN;
-        max_val_len = SINGLETON_VAL_LEN;
-        kvs_name = NULL;
-        max_name_len = 0;
-    }
-
-    kvs_key = (char*) malloc(max_key_len);
-    if (NULL == kvs_key) return 8;
-
-    kvs_value = (char*) malloc(max_val_len);
-    if (NULL == kvs_value) return 9;
-
+    kv_store_me = (char*)malloc(MAX_KV_COUNT * sizeof(char)* MAX_KV_LENGTH);
+    
     return 0;
 }
 
@@ -170,8 +84,11 @@ shmem_runtime_fini(void)
     if(!finalized){
         MPI_Finalize();
     }
+
     free(kv_store_all);
-    free(kv_store_me);
+    if(size != 1){
+        free(kv_store_me);
+    }
 
     return 0;
 }
@@ -213,22 +130,30 @@ shmem_runtime_get_size(void)
 int
 shmem_runtime_exchange(void)
 {
-    /* Use singleton KVS for single process jobs */
     if (size == 1){
+        kv_store_all = kv_store_me;
         return 0;
     }
-    
-    for(int i = 0; i < length; i++)
-    {
-        *(kv_store_all + i) = (char*)malloc(max_val_len * sizeof(char) * size);
 
-        if (MPI_SUCCESS != MPI_Allgather(*(kv_store_me+i), max_val_len, MPI_CHAR, *(kv_store_all + i), max_val_len, MPI_CHAR, SHMEM_RUNTIME_WORLD)) {
-            return 2;   
-        }
-        if (MPI_SUCCESS != MPI_Barrier(SHMEM_RUNTIME_WORLD)) {
-            return 6;
-        }
+    int chunkSize = length * sizeof(char) * MAX_KV_LENGTH;
+    kv_store_all = (char*)malloc(chunkSize * size);
+
+    if (MPI_SUCCESS != MPI_Allgather(kv_store_me, chunkSize, MPI_CHAR, kv_store_all, chunkSize, MPI_CHAR, SHMEM_RUNTIME_WORLD)) {
+        return 2;   
     }
+    if (MPI_SUCCESS != MPI_Barrier(SHMEM_RUNTIME_WORLD)) {
+        return 6;
+    }
+    // if(rank == 0){
+    //     for(int i = 0; i < length*size; i++){
+    //         printf("%s, %s, strcmp: %i\n", (kv_store_all + i * MAX_KV_LENGTH), (kv_store_me + i * MAX_KV_LENGTH), strcmp((kv_store_all + i * MAX_KV_LENGTH), kv_store_me + i * MAX_KV_LENGTH));
+    //     }
+    //     printf("\n");
+    // }
+    if (MPI_SUCCESS != MPI_Barrier(SHMEM_RUNTIME_WORLD)) {
+        return 6;
+    }
+    
     return 0;
 }
 
@@ -236,26 +161,15 @@ shmem_runtime_exchange(void)
 int 
 shmem_runtime_put(char *key, void *value, size_t valuelen)
 {
-    snprintf(kvs_key, max_key_len, "shmem-%lu-%s", (long unsigned) rank, key);
-    if (0 != encode(value, valuelen, kvs_value, max_val_len)) {
-        return 1;
-    }
+    if(length < MAX_KV_COUNT){
 
-    if (size == 1) {
-        singleton_kvs_t *e = malloc(sizeof(singleton_kvs_t));
-        if (e == NULL) return 3;
-        strncpy(e->key, kvs_key, max_key_len);
-        strncpy(e->val, kvs_value, max_val_len);
-        HASH_ADD_STR(singleton_kvs, key, e);
+        memcpy((kv_store_me + length * MAX_KV_LENGTH), key, MAX_KV_LENGTH);
+        length++;
+        memcpy((kv_store_me + length * MAX_KV_LENGTH), value, MAX_KV_LENGTH);
+        length++;
+
     } else {
-        if(length < 20){
-            *(kv_store_me + length) = key;
-            length++;
-            *(kv_store_me + length) = kvs_value;
-            length++;
-        } else {
-            return 20;
-        }
+        return MAX_KV_COUNT;
     }
 
     return 0;
@@ -264,25 +178,24 @@ shmem_runtime_put(char *key, void *value, size_t valuelen)
 int
 shmem_runtime_get(int pe, char *key, void *value, size_t valuelen)
 {
-	snprintf(kvs_key, max_key_len, "shmem-%lu-%s", (long unsigned) pe, key);
-    if (size == 1) {
-        singleton_kvs_t *e;
-        HASH_FIND_STR(singleton_kvs, kvs_key, e);
-        if (e == NULL)
-            return 3;
-        kvs_value = e->val;
-    }
-    else {
-        for(int i = 0; i < 2 * length; i += 2){
-            if(strcmp(key, (*(kv_store_all+i) + pe * max_val_len)) == 0){
-                kvs_value = (*(kv_store_all+i + 1) + pe * max_val_len);
-                break;
-            }
+    int flag = 0;
+    for(int i = pe * length; i < length * size; i+= 2){
+        if(strcmp((kv_store_all + i * MAX_KV_LENGTH), key) == 0){
+            memcpy(value, (kv_store_all + (i+1) * MAX_KV_LENGTH), valuelen);
+            // printf("Value found: %s for pe %i\n", (kv_store_all + (i+1) * MAX_KV_LENGTH ), pe);
+            // if(pe == rank){
+            //     printf("\nstrcmp: %i\n", strcmp((kv_store_me + MAX_KV_LENGTH), ((kv_store_all + (i+1) * MAX_KV_LENGTH))));
+            // }
+            flag = 1;
+            break;
         }
     }
-    if (0 != decode(kvs_value, value, valuelen)) {
-        return 2;
+    if(0 == flag){
+        return 3;
     }
+
+    MPI_Barrier(SHMEM_RUNTIME_WORLD);
+    
     return 0;
 }
 

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -4,7 +4,7 @@
  * DE-AC04-94AL85000 with Sandia Corporation, the U.S.  Government
  * retains certain rights in this software.
  *
- * Copyright (c) 2017 Intel Corporation. All rights reserved.
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
  * This software is available to you under the BSD license.
  *
  * This file is part of the Sandia OpenSHMEM software package. For license
@@ -97,3 +97,6 @@ SHMEM_INTERNAL_ENV_DEF(OFI_STX_ALLOCATOR, string, "round-robin", SHMEM_INTERNAL_
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_DISABLE_PRIVATE, bool, false, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Disallow private contexts from having exclusive STX access")
 #endif
+
+SHMEM_INTERNAL_ENV_DEF(SHMEM_MPI_THREAD_LEVEL, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+                       "Flag to determine the threading level for MPI when used as the proccess manager");

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1063,7 +1063,6 @@ int populate_av(void)
     }
 
     for (i = 0; i < shmem_internal_num_pes; i++) {
-        printf("transport_ofi loop: %i\n", i);
         char *addr_ptr = alladdrs + i * shmem_transport_ofi_addrlen;
         int toCheck = shmem_runtime_get(i, "fi_epname", addr_ptr, shmem_transport_ofi_addrlen); //TODO Ask Jim about having this check implemented
         printf("Sanity: %i\n", toCheck);
@@ -1086,14 +1085,10 @@ int populate_av(void)
                        addr_table,
                        0,
                        NULL);
-    // printf("ret: %i, internal_pes: %i\n", ret, shmem_internal_num_pes);
-    // printf("addr_table: %i", addr_table);
     if (ret != shmem_internal_num_pes) {
         RAISE_WARN_STR("av insert failed");
         return ret;
     }
-
-    printf("fi_av_insert success\n");
 
     free(alladdrs);
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1037,6 +1037,7 @@ int publish_av_info(struct fabric_info *info)
     ret = shmem_runtime_put("fi_epname", epname, epnamelen);
     OFI_CHECK_RETURN_STR(ret, "shmem_runtime_put fi_epname failed");
 
+
     /* Note: we assume that the length of an address is the same for all
      * endpoints.  This is safe for most HPC systems, but could be incorrect in
      * a heterogeneous context. */
@@ -1062,8 +1063,10 @@ int populate_av(void)
     }
 
     for (i = 0; i < shmem_internal_num_pes; i++) {
+        printf("transport_ofi loop: %i\n", i);
         char *addr_ptr = alladdrs + i * shmem_transport_ofi_addrlen;
-        shmem_runtime_get(i, "fi_epname", addr_ptr, shmem_transport_ofi_addrlen);
+        int toCheck = shmem_runtime_get(i, "fi_epname", addr_ptr, shmem_transport_ofi_addrlen); //TODO Ask Jim about having this check implemented
+        printf("Sanity: %i\n", toCheck);
 
 #ifdef USE_ON_NODE_COMMS
         shmem_runtime_get(i, "fi_ephostname", ephostname, EPHOSTNAMELEN);
@@ -1083,10 +1086,14 @@ int populate_av(void)
                        addr_table,
                        0,
                        NULL);
+    // printf("ret: %i, internal_pes: %i\n", ret, shmem_internal_num_pes);
+    // printf("addr_table: %i", addr_table);
     if (ret != shmem_internal_num_pes) {
         RAISE_WARN_STR("av insert failed");
         return ret;
     }
+
+    printf("fi_av_insert success\n");
 
     free(alladdrs);
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1064,11 +1064,18 @@ int populate_av(void)
 
     for (i = 0; i < shmem_internal_num_pes; i++) {
         char *addr_ptr = alladdrs + i * shmem_transport_ofi_addrlen;
-        int toCheck = shmem_runtime_get(i, "fi_epname", addr_ptr, shmem_transport_ofi_addrlen); //TODO Ask Jim about having this check implemented
-        printf("Sanity: %i\n", toCheck);
+        int err = shmem_runtime_get(i, "fi_epname", addr_ptr, shmem_transport_ofi_addrlen); //TODO Ask Jim about having this check implemented
+        if(err != 0){
+            RAISE_WARN_STR("Runtime get failed");
+        }
 
 #ifdef USE_ON_NODE_COMMS
         shmem_runtime_get(i, "fi_ephostname", ephostname, EPHOSTNAMELEN);
+  
+        if(err != 0){
+            RAISE_WARN_STR("Runtime get failed");
+        }
+  
         if (strncmp(myephostname, ephostname, EPHOSTNAMELEN) == 0) {
             SHMEM_SET_RANK_SAME_NODE(i, num_on_node++);
             if (num_on_node > 255) {


### PR DESCRIPTION
The algorithm for storing the Key-Value pairs was completely changed. In the previous version, it existed as a 2d table looking like this: 
```
Key: PE0 | PE1 | PE2 | PE3 | ... | PEn 
Val: PE0 | PE1 | PE2 | PE3 | ... | PEn
Key: PE0 | PE1 | PE2 | PE3 | ... | PEn
Val: PE0 | PE1 | PE2 | PE3 | ... | PEn
...
```

This was slow in ```runtime_exchange()``` as ```MPI_Allgather``` was required to be called for each key and value. To solve this, a single buffer is now used, formatted like this: 

```
PE0:                                    PE1: 
KeyA | ValA | KeyB | ValB | ... | KeyX | ValX | KeyA | ValA | KeyB | ValB | ... | KeyX | ValX 
```

This allows for a single ```MPI_Allgather``` to be called.